### PR TITLE
Provide README for autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,3 @@
 SUBDIRS = src doc
+
+README:	README.md


### PR DESCRIPTION
Fix `Makefile.am: error: required file './README' not found` by
providing a `README` target in Makefile.am, per
https://stackoverflow.com/questions/15013672/use-autotools-with-readme-md/44859139#44859139