### PR TITLE
registration_table: Add 'mac_address' field

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 2018-07-08, Version 1.1.3 (unreleased)
+	* registration_table: Added 'mac_address' field
 	* ros_interface: Added support for RouterOS 6.x splitted counters.
 	* ros: The “system-health” high-level command has been added.
 	* ros_system_health: Added high-level interface for

--- a/src/registration_table.c
+++ b/src/registration_table.c
@@ -111,6 +111,7 @@ static ros_registration_table_t *rt_reply_to_regtable (const ros_reply_t *r) /* 
 
 	ret->interface = ros_reply_param_val_by_key (r, "interface");
 	ret->radio_name = ros_reply_param_val_by_key (r, "radio-name");
+	ret->mac_address = ros_reply_param_val_by_key (r, "mac-address");
 
 	ret->ap = sstrtob (ros_reply_param_val_by_key (r, "ap"));
 	ret->wds = sstrtob (ros_reply_param_val_by_key (r, "wds"));

--- a/src/ros.c
+++ b/src/ros.c
@@ -81,7 +81,10 @@ static void regtable_dump (const ros_registration_table_t *r) /* {{{ */
 	if (r == NULL)
 		return;
 
-	printf ("=== %s / %s ===\n", r->interface, r->radio_name);
+	printf ("=== %s / %s ===\n", r->interface,
+			r->radio_name ? r->radio_name : r->mac_address);
+	if (r->mac_address)
+		printf ("MAC address:         %s\n", r->mac_address);
 	printf ("Mode:           %12s\n",
 			r->ap ? (r->wds ? "AP with WDS" : "Access point") : "Station");
 	printf ("Rate:           %7g Mbps / %7g Mbps\n", r->rx_rate, r->tx_rate);

--- a/src/routeros_api.h
+++ b/src/routeros_api.h
@@ -144,9 +144,12 @@ struct ros_registration_table_s
 	const char *interface;
 	/* Name of the remote radio */
 	const char *radio_name;
+	/* MAC address of the registered client */
+	const char *mac_address;
 
 	/* ap is set to true, if the REMOTE radio is an access point. */
 	_Bool ap;
+	/* whether the connected client is using wds or not */
 	_Bool wds;
 
 	/* Receive and transmit rate in MBit/s */


### PR DESCRIPTION

Collectd uses `radio-name` when sending metrics from `Registration Table`.
But there is no such field in table on my router.

So, client should be identified by MAC-address.

https://wiki.mikrotik.com/wiki/Manual:Interface/Wireless#Registration_Table

```
# ./ros 192.168.0.1 '/interface/wireless/registration-table/print'
Password for user admin:
Status: re
  Param 0: .id = *1
  Param 1: interface = wlan1
  Param 2: mac-address = 00:11:22:3E:1C:EE
  Param 3: ap = false
  Param 4: wds = false
  Param 5: bridge = false
  Param 6: rx-rate = 65Mbps-20MHz/1S
  Param 7: tx-rate = 48Mbps
  Param 8: packets = 34591,20635
  Param 9: bytes = 6689896,2094536
  Param 10: frames = 34591,22078
  Param 11: frame-bytes = 6853394,2125149
  Param 12: hw-frames = 483633,22078
  Param 13: hw-frame-bytes = 36949799,3008237
  Param 14: tx-frames-timed-out = 0
  Param 15: uptime = 5d9m11s
  Param 16: last-activity = 4s750ms
  Param 17: signal-strength = -51@1Mbps
  Param 18: signal-to-noise = 50
  Param 19: signal-strength-ch0 = -53
  Param 20: signal-strength-ch1 = -62
  Param 21: strength-at-rates = -51@1Mbps 5d8m55s380ms,-46@HT20-4 5m42s170ms,-47@HT20-5 38m4s330ms,-47@HT20-6 7m47s130ms,-47@HT20-7 44s850ms
  Param 22: tx-ccq = 113
  Param 23: p-throughput = 27568
  Param 24: last-ip = 192.168.88.10
  Param 25: 802.1x-port-enabled = true
  Param 26: authentication-type = wpa2-psk
  Param 27: encryption = aes-ccm
  Param 28: group-encryption = aes-ccm
  Param 29: management-protection = false
  Param 30: wmm-enabled = true
  Param 31: tx-rate-set = CCK:1-11 OFDM:6-54 BW:1x SGI:1x HT:0-7
===
Status: re
  Param 0: .id = *4
  Param 1: interface = wlan1
  Param 2: mac-address = 00:11:22:97:02:57
  Param 3: ap = false
  Param 4: wds = false
  Param 5: bridge = false
  Param 6: rx-rate = 26Mbps-20MHz/1S
  Param 7: tx-rate = 72.2Mbps-20MHz/1S/SGI
  Param 8: packets = 2355883,1873796
  Param 9: bytes = 2215539802,381772370
  Param 10: frames = 2355883,1875232
  Param 11: frame-bytes = 2220260168,370683268
  Param 12: hw-frames = 4869515,2262330
  Param 13: hw-frame-bytes = 3259632006,454984422
  Param 14: tx-frames-timed-out = 0
  Param 15: uptime = 4d23h29m25s
  Param 16: last-activity = 0ms
  Param 17: signal-strength = -50@6Mbps
  Param 18: signal-to-noise = 51
  Param 19: signal-strength-ch0 = -54
  Param 20: signal-strength-ch1 = -52
  Param 21: strength-at-rates = -59@1Mbps 2s190ms,-48@2Mbps 4d23h29m24s830ms,-48@11Mbps 1h47m58s510ms,-50@6Mbps 0ms,-45@12Mbps 1h22m34s630ms,-68@18Mbps 6m33s530ms,-49@24Mbps 1m41s600ms,-49@36Mbps 1m41s590ms,-51@48Mbps 5m24s480ms,-48@HT20-0 4d23h29m24s530ms,-46@HT20-1 11m8s470ms,-48@HT20-2 11s220ms,-49@HT20-3 990ms,-50@HT20-4 2s70ms,-51@HT20-5 11s320ms,-46@HT20-6 31s720ms,-50@HT20-7 2m30s610ms
  Param 22: tx-ccq = 88
  Param 23: p-throughput = 66758
  Param 24: last-ip = 192.168.88.47
  Param 25: 802.1x-port-enabled = true
  Param 26: authentication-type = wpa2-psk
  Param 27: encryption = aes-ccm
  Param 28: group-encryption = aes-ccm
  Param 29: management-protection = false
  Param 30: wmm-enabled = true
  Param 31: tx-rate-set = CCK:1-11 OFDM:6-54 BW:1x SGI:1x HT:0-15
===
Status: re
  Param 0: .id = *28
  Param 1: interface = wlan1
  Param 2: mac-address = 00:11:22:50:53:DD
  Param 3: ap = false
  Param 4: wds = false
  Param 5: bridge = false
  Param 6: rx-rate = 130Mbps-20MHz/2S/SGI
  Param 7: tx-rate = 144.4Mbps-20MHz/2S/SGI
  Param 8: packets = 1209561,524775
  Param 9: bytes = 1647827604,60652347
  Param 10: frames = 1209561,524822
  Param 11: frame-bytes = 1650246992,57508748
  Param 12: hw-frames = 1856519,535335
  Param 13: hw-frame-bytes = 2592381049,79024821
  Param 14: tx-frames-timed-out = 0
  Param 15: uptime = 3h47m45s
  Param 16: last-activity = 120ms
  Param 17: signal-strength = -42@HT20-6
  Param 18: signal-to-noise = 59
  Param 19: signal-strength-ch0 = -45
  Param 20: signal-strength-ch1 = -47
  Param 21: strength-at-rates = -46@1Mbps 26s600ms,-42@2Mbps 3h47m22s670ms,-45@5.5Mbps 3h47m27s140ms,-41@11Mbps 3h47m26s600ms,-44@HT20-0 3h47m23s610ms,-43@HT20-1 3h46m36s290ms,-43@HT20-2 3h47m24s440ms,-43@HT20-3 3h46m52s840ms,-43@HT20-4 6m21s660ms,-42@HT20-5 14s440ms,-42@HT20-6 190ms,-41@HT20-7 31s660ms
  Param 22: tx-ccq = 98
  Param 23: p-throughput = 130292
  Param 24: last-ip = 192.168.88.242
  Param 25: 802.1x-port-enabled = true
  Param 26: authentication-type = wpa2-psk
  Param 27: encryption = aes-ccm
  Param 28: group-encryption = aes-ccm
  Param 29: management-protection = false
  Param 30: wmm-enabled = true
  Param 31: tx-rate-set = CCK:1-11 OFDM:6-54 BW:1x SGI:1x HT:0-15
===
Status: re
  Param 0: .id = *32
  Param 1: interface = wlan1
  Param 2: mac-address = 00:11:22:8A:5B:EA
  Param 3: ap = false
  Param 4: wds = false
  Param 5: bridge = false
  Param 6: rx-rate = 57.7Mbps-20MHz/1S/SGI
  Param 7: tx-rate = 115.5Mbps-20MHz/2S/SGI
  Param 8: packets = 347,542
  Param 9: bytes = 117868,84448
  Param 10: frames = 255,550
  Param 11: frame-bytes = 120281,82074
  Param 12: hw-frames = 456,1667
  Param 13: hw-frame-bytes = 306718,131198
  Param 14: tx-frames-timed-out = 0
  Param 15: uptime = 17m28s
  Param 16: last-activity = 90ms
  Param 17: signal-strength = -71@24Mbps
  Param 18: signal-to-noise = 30
  Param 19: signal-strength-ch0 = -80
  Param 20: signal-strength-ch1 = -72
  Param 21: strength-at-rates = -75@1Mbps 1s260ms,-69@6Mbps 10m43s660ms,-71@24Mbps 90ms,-74@HT20-0 11m5s110ms,-71@HT20-1 8m27s340ms,-70@HT20-2 46s640ms,-71@HT20-3 1s300ms,-77@HT20-4 3m36s70ms,-72@HT20-5 150ms,-72@HT20-6 3m36s430ms,-73@HT20-7 3m38s780ms
  Param 22: tx-ccq = 92
  Param 23: p-throughput = 34537
  Param 24: last-ip = 192.168.88.19
  Param 25: 802.1x-port-enabled = true
  Param 26: authentication-type = wpa2-psk
  Param 27: encryption = aes-ccm
  Param 28: group-encryption = aes-ccm
  Param 29: management-protection = false
  Param 30: wmm-enabled = true
  Param 31: tx-rate-set = CCK:1-11 OFDM:6-54 BW:1x SGI:1x HT:0-15
===
Status: done
===
```