### PR TITLE
Added configurable receive timeout

### DIFF
--- a/doc/librouteros.pod
+++ b/doc/librouteros.pod
@@ -45,6 +45,11 @@ I<username> and I<password>.
 
 On failure, C<NULL> is returned and B<errno> is set appropriately.
 
+=item ros_connection_t *B<ros_connect_timeout> (const char *I<node>, const char *I<service>, const char *I<username>, const char *I<password>, const struct timeval *I<timeout>)
+
+Same as B<ros_connect> but configures a receive timeout. If receive times out
+then the reply recevied so far (if any) is returned.
+
 =item int B<ros_disconnect> (ros_connection_t *I<c>)
 
 Disconnects from the device and frees all memory associated with the

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,8 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <fcntl.h>
+#include <sys/time.h>
 
 #include "md5/md5.h"
 
@@ -112,7 +114,7 @@ static int read_exact (int fd, void *buffer, size_t buffer_size) /* {{{ */
 		status = read (fd, buffer_ptr, want_bytes);
 		if (status < 0)
 		{
-			if (errno == EAGAIN || errno == EINTR)
+			if (errno == EINTR)
 				continue;
 			else
 				return (status);
@@ -602,7 +604,7 @@ static ros_reply_t *receive_reply (ros_connection_t *c) /* {{{ */
 	return (head);
 } /* }}} ros_reply_t *receive_reply */
 
-static int create_socket (const char *node, const char *service) /* {{{ */
+static int create_socket (const char *node, const char *service, const struct timeval *timeout) /* {{{ */
 {
 	struct addrinfo  ai_hint;
 	struct addrinfo *ai_list;
@@ -644,6 +646,17 @@ static int create_socket (const char *node, const char *service) /* {{{ */
 			ros_debug ("create_socket: connect(2) failed.\n");
 			close (fd);
 			continue;
+		}
+
+		// Set receive timeout on the socket if one is set
+		if(NULL != timeout)
+		{
+			if (setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, (char *)timeout, sizeof(struct timeval)) < 0)
+			{
+				ros_debug ("create_socket: setsockopt() failed.\n");
+				close (fd);
+				continue;
+			}
 		}
 
 		freeaddrinfo (ai_list);
@@ -808,6 +821,12 @@ static int login_handler (ros_connection_t *c, const ros_reply_t *r, /* {{{ */
 ros_connection_t *ros_connect (const char *node, const char *service, /* {{{ */
 		const char *username, const char *password)
 {
+	return ros_connect_timeout(node, service, username, password, NULL);
+} /* }}} ros_connection_t *ros_connect */
+
+ros_connection_t *ros_connect_timeout (const char *node, const char *service, /* {{{ */
+		const char *username, const char *password, const struct timeval *timeout)
+{
 	int fd;
 	ros_connection_t *c;
 	int status;
@@ -820,7 +839,7 @@ ros_connection_t *ros_connect (const char *node, const char *service, /* {{{ */
 	if ((node == NULL) || (username == NULL) || (password == NULL))
 		return (NULL);
 
-	fd = create_socket (node, (service != NULL) ? service : ROUTEROS_API_PORT);
+	fd = create_socket (node, (service != NULL) ? service : ROUTEROS_API_PORT, timeout);
 	if (fd < 0)
 		return (NULL);
 

--- a/src/routeros_api.h
+++ b/src/routeros_api.h
@@ -23,6 +23,7 @@
 
 #include <stdint.h>
 #include <inttypes.h>
+#include <sys/time.h>
 
 #include <routeros_version.h>
 
@@ -69,6 +70,8 @@ typedef int (*ros_reply_handler_t) (ros_connection_t *c, const ros_reply_t *r,
  */
 ros_connection_t *ros_connect (const char *node, const char *service,
 		const char *username, const char *password);
+ros_connection_t *ros_connect_timeout (const char *node, const char *service,
+		const char *username, const char *password, const struct timeval *timeout);
 int ros_disconnect (ros_connection_t *con);
 
 /* 


### PR DESCRIPTION
The fix in b020d5c looks like it probably fixes the inital issue this work was for (hang when mikrotik reboots), but the receive timeout still gets around the potential issue where the the library can block forever if the connection drops half way through a request.

TODO: Associated setting in the routeros collectd plugin.
TODO: Configurable connect timeout.