### PR TITLE
Added connect timeout

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <sys/time.h>
+#include <fcntl.h>
 
 #include "md5/md5.h"
 
@@ -603,6 +604,83 @@ static ros_reply_t *receive_reply (ros_connection_t *c) /* {{{ */
 	return (head);
 } /* }}} ros_reply_t *receive_reply */
 
+static int connect_socket_timeout (struct addrinfo *ai_ptr, unsigned int timeout_sec)
+{
+	struct timeval timeout = {
+		.tv_sec = timeout_sec,
+	};
+
+	/* value of 0 means no timeout, select treats NULL as no timeout */
+	struct timeval *timeout_ptr = (0 == timeout_sec)? NULL : &timeout;
+
+	int fd;
+	int status;
+
+	fd = socket (ai_ptr->ai_family, ai_ptr->ai_socktype, ai_ptr->ai_protocol);
+	if (fd < 0)
+	{
+		ros_debug ("connect_socket_timeout: socket(2) failed.\n");
+		return (0);
+	}
+
+	/* set socket nonblocking just for the connect() - allows us to call select() on connecting socket */
+	fcntl(fd, F_SETFL, O_NONBLOCK);
+
+	status = connect (fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
+	if (status != 0 && (errno != EINPROGRESS))
+	{
+		/* connect() failed due to some reason other than a timeout */
+		ros_debug ("connect_socket_timeout: connect(2) failed.\n");
+		close (fd);
+		return (0);
+	}
+
+	fd_set fdset;
+	FD_ZERO (&fdset);
+	FD_SET (fd, &fdset);
+
+	if (1 == select (fd + 1, NULL, &fdset, NULL, timeout_ptr))
+	{
+		/* find out what happened to the socket */
+		int socket_error;
+		socklen_t len = sizeof(socket_error);
+
+		if (0 != getsockopt (fd, SOL_SOCKET, SO_ERROR, &socket_error, &len))
+		{
+			ros_debug ("connect_socket_timeout: getsockopt() failed\n");
+			close (fd);
+			return (0);
+		}
+
+		if (0 != socket_error)
+		{
+			ros_debug ("connect_socket_timeout: connect() failed.\n");
+			close (fd);
+
+			/* fill in errno so the caller knows what happened */
+			errno = socket_error;
+			return (0);
+		}
+	}
+	else
+	{
+		ros_debug ("connect_socket_timeout: select() failed.\n");
+		close (fd);
+
+		/* replace error code as ETIMEDOUT is more representative than EINPROGRESS */
+		if (EINPROGRESS == errno)
+		{
+			errno = ETIMEDOUT;
+		}
+
+		return 0;
+	}
+
+	/* convert the socket back to blocking mode */
+	fcntl (fd, F_SETFL, 0);
+	return (fd);
+} /* }}} int *try_connect */
+
 static int create_socket (const char *node, const char *service, const ros_connect_opts_t *connect_opts) /* {{{ */
 {
 	struct addrinfo  ai_hint;
@@ -629,21 +707,20 @@ static int create_socket (const char *node, const char *service, const ros_conne
 	for (ai_ptr = ai_list; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next)
 	{
 		int fd;
-		int status;
 
-		fd = socket (ai_ptr->ai_family, ai_ptr->ai_socktype,
-				ai_ptr->ai_protocol);
-		if (fd < 0)
+		if (connect_opts && connect_opts->connect_timeout)
 		{
-			ros_debug ("create_socket: socket(2) failed.\n");
-			continue;
+			fd = connect_socket_timeout (ai_ptr, connect_opts->connect_timeout);
+		}
+		else
+		{
+			/* timeout value of 0 means inf timeout */
+			fd = connect_socket_timeout (ai_ptr, 0);
 		}
 
-		status = connect (fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen);
-		if (status != 0)
+		if(0 == fd)
 		{
-			ros_debug ("create_socket: connect(2) failed.\n");
-			close (fd);
+			/* connection failed, try the next host */
 			continue;
 		}
 

--- a/src/ros.c
+++ b/src/ros.c
@@ -41,6 +41,7 @@
 
 static const char *opt_username = "admin";
 static int opt_receive_timeout = 0;
+static int opt_connect_timeout = 0;
 
 static int result_handler (ros_connection_t *c, const ros_reply_t *r, /* {{{ */
 		void *user_data)
@@ -301,6 +302,7 @@ static void exit_usage (void) /* {{{ */
 			"OPTIONS:\n"
 			"  -u <user>       Use <user> to authenticate (optional, default: admin).\n"
 			"  -t <timeout>    Set receive timeout in seconds.\n"
+			"  -c <timeout>    Set connect timeout in seconds.\n"
 			"  -h              Display this help message.\n"
 			"\n");
 	if (ros_version () == ROS_VERSION)
@@ -322,7 +324,7 @@ int main (int argc, char **argv) /* {{{ */
 
 	int option;
 
-	while ((option = getopt (argc, argv, "u:t:h?")) != -1)
+	while ((option = getopt (argc, argv, "u:t:c:h?")) != -1)
 	{
 		switch (option)
 		{
@@ -332,7 +334,9 @@ int main (int argc, char **argv) /* {{{ */
 			case 't':
 				opt_receive_timeout = atoi(optarg);
 				break;
-
+			case 'c':
+				opt_connect_timeout = atoi(optarg);
+				break;
 			case 'h':
 			case '?':
 			default:
@@ -354,6 +358,7 @@ int main (int argc, char **argv) /* {{{ */
 	/* prepare struct with options */
 	ros_connect_opts_t opts = {
 		.receive_timeout = opt_receive_timeout,
+		.connect_timeout = opt_connect_timeout,
 	};
 	c = ros_connect_with_options (host, ROUTEROS_API_PORT,
 			opt_username, passwd, &opts);

--- a/src/routeros_api.h
+++ b/src/routeros_api.h
@@ -72,7 +72,7 @@ struct ros_connect_opts_s
 	/* receive_timeout is the receive timeout in seconds. */
 	unsigned int receive_timeout;
 	/* connect_timeout is the connect timeout in seconds. */
-	unsigned int connect_timeout; /* Not yet implemented! */
+	unsigned int connect_timeout;
 };
 typedef struct ros_connect_opts_s ros_connect_opts_t;
 


### PR DESCRIPTION
Added connect timeout using select().

There are some places where I assign manually to errno as it will not be set correctly to the error encountered from the connect() call but instead will be that from the select() call. I'm not sure is this is the right thing to do here, but I can't think of any other way to do it without changing the way the library works (e.g. negative error code in the return value).